### PR TITLE
Add simple dataset scorer

### DIFF
--- a/assets/AH_Evaluators/steijn/dataset_scorer.yaml
+++ b/assets/AH_Evaluators/steijn/dataset_scorer.yaml
@@ -1,0 +1,43 @@
+# Evaluator: General Query Evaluator
+category: Dataset Evaluator
+evaluation_criteria: >
+  You are an expert evaluator assessing how well the assistant’s **Text Message** and **Data Message** align with the **user question** and the **expected output** for inquiries about recipes, cooking advice, and products (both food and non-food) from Albert Heijn, on a scale from 0.0 to 1.0.
+  
+  ## Input
+      - You will receive a text representing the assistant's response to a user query, which includes:
+      - **Text Message**: The main response from the assistant.
+      - **Data Message**: Additional recipe or product context or information that supports the **Text Message**. (Optional)
+  
+  ## Expected Output
+      - A reference **expected output**: ({{ expected_output }}). 
+      - Expected output can be in detail or in a generic way.
+  
+  ## User's request
+      - The **user request**: ({{ request_prompt }})
+  
+  ## Your Role
+  Compare the assistant’s response to the expected output with a focus on semantic similarity, relevance, and domain alignment. 
+  Do the following: in order to determine the score:
+      - The **Text Message** aligns with the expected output.
+      - If step 1 is correct, check if the **Text Message** fully answers the user’s inquiry by providing a clear, concise, and actionable response.
+      - If the **Text Message** is relevant but does not fully answer the inquiry, check if it provides a partial response that is still useful.
+      - Finally, check if the **Data Message** is relevant and provides additional context or information that supports the **Text Message**.
+  
+  ## Scoring Guide (0.0 to 1.0)
+  - **Score closer to 1.0:**
+      - The response aligns with the expected output in content. 
+      - The **Text Message** delivers an accurate, complete, and actionable answer that fits the user's request.
+  - **Score around 0.5:**
+      - The response offers partial alignment or relevance to the expected output.
+      - The **Text Message** provides a useful but incomplete answer, or it includes some inaccuracies or irrelevant details.
+  - **Score closer to 0.0:**
+      - The response is completely off-target or irrelevant to the expected output.
+  
+  ## Clarifications
+  - The **expected output** is indicative and does not require an exact match.
+  - Variations in phrasing are acceptable if the overall content is preserved.
+  
+  ## Output
+  score_value: 0.0 to 1.0
+  
+  score_rationale: Provide a concise justification explaining the assigned score.

--- a/pyrit/common/text_helper.py
+++ b/pyrit/common/text_helper.py
@@ -264,7 +264,7 @@ def _render_report_html(
 
 def generate_simulation_report(
         results: list,
-        threshold: float = 0.9,
+        threshold: float = 0.8,
         title: str = "Comprehensive Simulation Report",
         description: str = "",
         execution_time: float = 0.0,
@@ -288,7 +288,7 @@ def generate_simulation_report(
 
 def generate_dataset_report(
         results: list,
-        threshold: float = 0.7,
+        threshold: float = 0.5,
         title: str = "Comprehensive Dataset Report",
         description: str = "",
         execution_time: float = 0.0,

--- a/pyrit/orchestrator/single_turn/steijn/steijn_prompt_sending_orchestrator.py
+++ b/pyrit/orchestrator/single_turn/steijn/steijn_prompt_sending_orchestrator.py
@@ -4,6 +4,7 @@
 import re
 import asyncio
 import logging
+import time
 import uuid
 from typing import Any, Optional, Sequence, List, Dict, Coroutine
 
@@ -209,6 +210,10 @@ class SteijnPromptSendingOrchestrator(Orchestrator):
                 conversation_id = str(uuid.uuid4())
 
             await self._add_prepended_conversation_to_memory(prepended_conversation, conversation_id)
+
+            # Multi-step conversations return 500 occasionally when assistant state is busy and we send a new request.
+            # This is a workaround to wait for the assistant to be ready.
+            await asyncio.sleep(20)
 
             prompt_request_response = await self._prompt_normalizer.send_prompt_async(
                 seed_prompt_group=seed_prompt,

--- a/pyrit/prompt_target/http_target/steijn/steijn_response_parser.py
+++ b/pyrit/prompt_target/http_target/steijn/steijn_response_parser.py
@@ -11,9 +11,9 @@ class SteijnResponseParser:
     @staticmethod
     def parse_response(response):
         """Parses the assistant's response content and extracts structured data."""
+
         response_data = {}
         response_text = response.content.decode("utf-8")
-
         for field in SteijnResponseParser.response_fields_regex_dict:
             matches = re.findall(field["pattern"], response_text, re.DOTALL)
 
@@ -34,4 +34,7 @@ class SteijnResponseParser:
 
                 response_data[field["name"]] = content
 
+        if response_data == {}:
+            # If no matches found, return the entire response as a fallback
+            response_data["Response body: "] = response_text
         return response_data


### PR DESCRIPTION
Implemented a basic dataset scorer that evaluates the relevance of the assistant’s response based on the user request, expected output, and actual assistant reply.

I validated the scorer on the regression dataset, achieving a pass rate of 93 out of 105 cases. This new scoring approach provides significantly improved accuracy compared to the previous method.

During testing, I identified an issue where sending messages too quickly to the assistant caused 500 errors due to the assistant’s state being busy, currently this is not a bug but a limitation of the current design. To bypass this on PyRIT side, I introduced a hardcoded delay for multi-turn conversations to ensure stable interaction.